### PR TITLE
Refactor to clarify symbol and statement layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # dc10
-A simplified AST for Scala code generation.
-
-### *Status: experimenting with term models*
+A purely functional AST for Scala code generation.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # dc10
 A purely functional AST for Scala code generation.
+
+### *Status: experimenting with term metadata models*

--- a/modules/compile/src/main/scala/dc10/compile/Compiler.scala
+++ b/modules/compile/src/main/scala/dc10/compile/Compiler.scala
@@ -5,18 +5,18 @@ import cats.kernel.Monoid
 trait Compiler[F[_], G[_]]:
 
   type Ctx[_[_], _, _]  // Monadic context, in which to build up ASTs and then compile them.
-  type Defn             // Definition level, representing introduction into the context.
+  type Def              // Definition level, representing introduction into the context.
   type Err              // Error type, parameterizing the context and the compilation results.
   type Fil              // File level, representing a source file with path and ast.
   
   extension [L: Monoid, A] (ast: Ctx[F, L, A])
     def compile: F[L]
 
-  extension (res: F[G[Defn]])
-    def toString[V](using R: Renderer[V, Err, G[Defn]]): String
+  extension (res: F[G[Def]])
+    def toString[V](using R: Renderer[V, Err, G[Def]]): String
 
-  extension (res: F[G[Defn]])
-    def toStringOrError[V](using R: Renderer[V, Err, G[Defn]]): F[String]
+  extension (res: F[G[Def]])
+    def toStringOrError[V](using R: Renderer[V, Err, G[Def]]): F[String]
 
   extension (res: F[List[Fil]])
-    def toVirtualFile[V](using R: Renderer[V, Err, G[Defn]]): F[List[VirtualFile]]
+    def toVirtualFile[V](using R: Renderer[V, Err, G[Def]]): F[List[VirtualFile]]

--- a/modules/compile/src/main/scala/dc10/compile/Compiler.scala
+++ b/modules/compile/src/main/scala/dc10/compile/Compiler.scala
@@ -6,9 +6,8 @@ trait Compiler[F[_], G[_]]:
 
   type Ctx[_[_], _, _]  // Monadic context, in which to build up ASTs and then compile them.
   type Defn             // Definition level, representing introduction into the context.
-  type Ent              // Entity level, i.e., all sorts, to be expressed, defined, and referenced.
-  type Err              // Error type, parameterizing the context and the evaluation results.
-  type Src              // File level, representing a source file with path and ast.
+  type Err              // Error type, parameterizing the context and the compilation results.
+  type Fil              // File level, representing a source file with path and ast.
   
   extension [L: Monoid, A] (ast: Ctx[F, L, A])
     def compile: F[L]
@@ -19,5 +18,5 @@ trait Compiler[F[_], G[_]]:
   extension (res: F[G[Defn]])
     def toStringOrError[V](using R: Renderer[V, Err, G[Defn]]): F[String]
 
-  extension (res: F[List[Src]])
+  extension (res: F[List[Fil]])
     def toVirtualFile[V](using R: Renderer[V, Err, G[Defn]]): F[List[VirtualFile]]

--- a/modules/scala/src/main/scala/dc10/scala/ast/Binding.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ast/Binding.scala
@@ -1,7 +1,8 @@
 package dc10.scala.ast
 
 import java.nio.file.Path
-import dc10.scala.ast.Binding.Term.ValueLevel
+import dc10.scala.ast.Binding.Term.{TypeLevel, ValueLevel}
+import dc10.scala.ast.Statement.Expr
 
 sealed trait Binding
 
@@ -11,10 +12,9 @@ object Binding:
   sealed abstract class CaseClass[T] extends Binding:
     type Tpe = T
     def nme: String
-    def tpe: Term.TypeLevel[T]
+    def tpe: Expr[TypeLevel, T]
     def fields: List[Statement.ValDef]
     def body: List[Statement]
-    // def ctor: Term.ValueLevel[A => T]
 
   object CaseClass:
     def apply[T](
@@ -24,10 +24,9 @@ object Binding:
       new CaseClass[T]:
         type Tpe = T
         def nme = n
-        def tpe: Term.TypeLevel[T] = Term.TypeLevel.Var.UserDefinedType[T](n, None)
+        def tpe: Expr[TypeLevel, T] = Expr.UserType(Term.TypeLevel.Var.UserDefinedType[T](n, None))
         def fields = fs
         def body = Nil
-        // def ctor: Term.ValueLevel[A => T] = ???
 
   // Package //////////////////////////////////////////////////////////////////
   sealed abstract class Package extends Binding
@@ -62,29 +61,29 @@ object Binding:
     sealed trait TypeLevel[T] extends Term
     object TypeLevel:
       type __
-      case class App1[T[_], A](tfun: Term.TypeLevel[T[__]], targ: Term.TypeLevel[A]) extends Term.TypeLevel[T[A]]
-      case class App2[T[_,_], A, B](tfun: Term.TypeLevel[T[__,__]], ta: Term.TypeLevel[A], tb: Term.TypeLevel[B]) extends Term.TypeLevel[T[A, B]]
-      sealed trait Lam1[F[_]] extends Term.TypeLevel[F[__]]
-      sealed trait Lam2[F[_,_]] extends Term.TypeLevel[F[__,__]]
-      sealed abstract class Var[T] extends Term.TypeLevel[T]
+      case class App1[T[_], A](tfun: Expr[TypeLevel, T[__]], targ: Expr[TypeLevel, A]) extends TypeLevel[T[A]]
+      case class App2[T[_,_], A, B](tfun: Expr[TypeLevel, T[__,__]], ta: Expr[TypeLevel, A], tb: Expr[TypeLevel, B]) extends TypeLevel[T[A, B]]
+      sealed trait Lam1[F[_]] extends TypeLevel[F[__]]
+      sealed trait Lam2[F[_,_]] extends TypeLevel[F[__,__]]
+      sealed abstract class Var[T] extends TypeLevel[T]
       object Var:
         case object BooleanType extends Var[Boolean]
         case object IntType extends Var[Int]
         case object StringType extends Var[String]
         case object Function1Type extends Var[__ => __]
         case object ListType extends Var[List[__]]
-        case class UserDefinedType[T](nme: String, impl: Option[Term.TypeLevel[T]]) extends Var[T]
+        case class UserDefinedType[T](nme: String, impl: Option[Expr[TypeLevel, T]]) extends Var[T]
         
     sealed trait ValueLevel[T] extends Term
     object ValueLevel:
-      case class App1[A, B](fun: Term.ValueLevel[A => B], arg: Term.ValueLevel[A]) extends Term.ValueLevel[B]
-      case class AppCtor1[T, A](tpe: Term.TypeLevel[T], arg: Term.ValueLevel[A]) extends Term.ValueLevel[T]
-      case class AppVargs[A, B](fun: Term.ValueLevel[List[A] => B], vargs: ValueLevel[A]*) extends Term.ValueLevel[B]
-      case class Lam1[A, B](a: Term.ValueLevel[A], b: Term.ValueLevel[B]) extends Term.ValueLevel[A => B]
+      case class App1[A, B](fun: Expr[ValueLevel, A => B], arg: Expr[ValueLevel, A]) extends Term.ValueLevel[B]
+      case class AppCtor1[T, A](tpe: Expr[TypeLevel, T], arg: Expr[ValueLevel, A]) extends Term.ValueLevel[T]
+      case class AppVargs[A, B](fun: Expr[ValueLevel, List[A] => B], vargs: Expr[ValueLevel, A]*) extends Term.ValueLevel[B]
+      case class Lam1[A, B](a: Expr[ValueLevel.Var.UserDefinedValue, A], b: Expr[ValueLevel, B]) extends Term.ValueLevel[A => B]
       sealed abstract class Var[T] extends Term.ValueLevel[T]
       object Var:
         case class BooleanLiteral(b: Boolean) extends Var[Boolean]
         case class IntLiteral(i: Int) extends Var[Int]
         case class StringLiteral(s: String) extends Var[String]
         case class ListCtor[A]() extends Var[List[A] => List[A]]
-        case class UserDefinedValue[T](nme: String, tpe: Term.TypeLevel[T], impl: Option[ValueLevel[T]]) extends Var[T]
+        case class UserDefinedValue[T](nme: String, tpe: Expr[TypeLevel, T], impl: Option[Expr[ValueLevel, T]]) extends Var[T]

--- a/modules/scala/src/main/scala/dc10/scala/ast/Statement.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ast/Statement.scala
@@ -1,8 +1,8 @@
 package dc10.scala.ast
 
-import dc10.scala.ast.Binding.{CaseClass, Package, Term}
+import Symbol.{CaseClass, Package, Term}
 import org.tpolecat.sourcepos.SourcePos
-import dc10.scala.ast.Binding.Term.ValueLevel
+import Symbol.Term.ValueLevel
 
 
 sealed trait Statement:

--- a/modules/scala/src/main/scala/dc10/scala/ast/Statement.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ast/Statement.scala
@@ -2,6 +2,7 @@ package dc10.scala.ast
 
 import dc10.scala.ast.Binding.{CaseClass, Package, Term}
 import org.tpolecat.sourcepos.SourcePos
+import dc10.scala.ast.Binding.Term.ValueLevel
 
 
 sealed trait Statement:
@@ -10,36 +11,21 @@ sealed trait Statement:
   
 object Statement:
 
-  // def indent(s: Statement): Statement =
-  //   s match
-  //     case b@ObjectDef(_, _, i) => b.copy(indent = i + 1)
-  //     case b@PackageDef(_, _, i) => b.copy(indent = i + 1)
-  //     case b@TypeDef(_, _, i) => b.copy(indent = i + 1)
-  //     case b@DefDef(_, _, i) => b.copy(indent = i + 1)
-  //     case b@ValDef(_, _, i) => b.copy(indent = i + 1)
-
-  // case class PackageDef(
-  //   pkg: Package,
-  //   sp: SourcePos,
-  //   indent: Int,
-  // ) extends Statement
-
-
-  sealed abstract case class RecordDef(
+  sealed abstract case class CaseClassDef(
     indent: Int,
     sp: SourcePos
   ) extends Statement:
     type Tpe
     def caseclass: CaseClass[Tpe]
 
-  object RecordDef:
+  object CaseClassDef:
     def apply[T](
       v: CaseClass[T],
       i: Int
     )(
       using sp: SourcePos
-    ): RecordDef =
-      new RecordDef(i, sp):
+    ): CaseClassDef =
+      new CaseClassDef(i, sp):
         type Tpe = T
         def caseclass: CaseClass[T] = v
 
@@ -70,11 +56,11 @@ object Statement:
     sp: SourcePos
   ) extends Statement:
     type Tpe
-    def value: Term.ValueLevel.Var.UserDefinedValue[Tpe]
+    def value: Expr[Term.ValueLevel.Var.UserDefinedValue, Tpe]
 
   object ValDef:
     def apply[T](
-      v: Term.ValueLevel.Var.UserDefinedValue[T]
+      v: Expr[Term.ValueLevel.Var.UserDefinedValue, T]
     )(
       i: Int
     )(
@@ -82,4 +68,29 @@ object Statement:
     ): ValDef =
       new ValDef(i, sp):
         type Tpe = T
-        def value: Term.ValueLevel.Var.UserDefinedValue[T] = v
+        def value: Expr[Term.ValueLevel.Var.UserDefinedValue, T] = v
+
+
+  sealed trait Expr[+F[_], T] extends Statement:
+    type Tpe = T
+    def value: F[Tpe]
+
+  object Expr:
+
+    case class BuiltInType[T](value: Term.TypeLevel[T]) extends Expr[Term.TypeLevel, T]:
+      def indent: Int = 0
+      def sp: SourcePos = summon[SourcePos]
+
+    case class BuiltInValue[T](value: Term.ValueLevel[T]) extends Expr[Term.ValueLevel, T]:
+      def indent: Int = 0
+      def sp: SourcePos = summon[SourcePos]
+     
+    case class UserType[T](value: Term.TypeLevel.Var.UserDefinedType[T]) extends Expr[Term.TypeLevel.Var.UserDefinedType, T]:
+      def indent: Int = 0
+      def sp: SourcePos = summon[SourcePos]
+
+    case class UserValue[T](value: Term.ValueLevel.Var.UserDefinedValue[T]) extends Expr[Term.ValueLevel.Var.UserDefinedValue, T]:
+      def indent: Int = 0
+      def sp: SourcePos = summon[SourcePos]
+
+      

--- a/modules/scala/src/main/scala/dc10/scala/ast/Symbol.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ast/Symbol.scala
@@ -1,15 +1,15 @@
 package dc10.scala.ast
 
 import java.nio.file.Path
-import dc10.scala.ast.Binding.Term.{TypeLevel, ValueLevel}
+import dc10.scala.ast.Symbol.Term.{TypeLevel, ValueLevel}
 import dc10.scala.ast.Statement.Expr
 
-sealed trait Binding
+sealed trait Symbol
 
-object Binding:
+object Symbol:
 
   // Templates ////////////////////////////////////////////////////////////////
-  sealed abstract class CaseClass[T] extends Binding:
+  sealed abstract class CaseClass[T] extends Symbol:
     type Tpe = T
     def nme: String
     def tpe: Expr[TypeLevel, T]
@@ -29,7 +29,7 @@ object Binding:
         def body = Nil
 
   // Package //////////////////////////////////////////////////////////////////
-  sealed abstract class Package extends Binding
+  sealed abstract class Package extends Symbol
 
   object Package:
 
@@ -54,7 +54,7 @@ object Binding:
     ) extends Package
 
   // Term ///////////////////////////////////////////////////////////////
-  sealed abstract class Term extends Binding
+  sealed abstract class Term extends Symbol
 
   object Term:
 

--- a/modules/scala/src/main/scala/dc10/scala/compiler.scala
+++ b/modules/scala/src/main/scala/dc10/scala/compiler.scala
@@ -4,7 +4,7 @@ import cats.data.StateT
 import cats.kernel.Monoid
 import dc10.compile.{Compiler, Renderer}
 import dc10.compile.VirtualFile
-import dc10.scala.ast.{Binding, Statement}
+import dc10.scala.ast.Statement
 import dc10.scala.file.ScalaFile
 import dc10.scala.error.CompileError
 
@@ -14,9 +14,8 @@ implicit object compiler extends Compiler[ErrorF, List]:
 
   type Ctx[F[_], L, A] = StateT[F, L, A]
   type Defn = Statement
-  type Ent = Binding
   type Err = CompileError
-  type Src = ScalaFile
+  type Fil = ScalaFile
 
   extension [L: Monoid, A] (ast: StateT[ErrorF, L, A])
     def compile: ErrorF[L] =

--- a/modules/scala/src/main/scala/dc10/scala/compiler.scala
+++ b/modules/scala/src/main/scala/dc10/scala/compiler.scala
@@ -13,7 +13,7 @@ type ErrorF[A] = Either[List[CompileError], A]
 implicit object compiler extends Compiler[ErrorF, List]:
 
   type Ctx[F[_], L, A] = StateT[F, L, A]
-  type Defn = Statement
+  type Def = Statement
   type Err = CompileError
   type Fil = ScalaFile
 

--- a/modules/scala/src/main/scala/dc10/scala/ctx/predef/Applications.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ctx/predef/Applications.scala
@@ -2,51 +2,52 @@ package dc10.scala.ctx.predef
 
 import cats.implicits.*
 import cats.data.StateT
-import dc10.scala.ast.Binding
 import dc10.scala.ast.Binding.Term
 import dc10.scala.ast.Binding.Term.TypeLevel.__
+import dc10.scala.ast.Binding.Term.{TypeLevel, ValueLevel}
 import dc10.scala.ast.Statement
+import dc10.scala.ast.Statement.Expr
 import dc10.scala.ctx.ErrorF
 
 trait Applications[F[_]]:
 
-  extension [T[_]] (function: F[Term.TypeLevel[T[__]]])
+  extension [T[_]] (function: F[Expr[TypeLevel, T[__]]])
     @scala.annotation.targetName("app1T")
-    def apply[A](args: F[Term.TypeLevel[A]]): F[Term.TypeLevel[T[A]]]
+    def apply[A](args: F[Expr[TypeLevel, A]]): F[Expr[TypeLevel, T[A]]]
 
-  extension [T[_,_]] (tfunction: F[Term.TypeLevel.Lam2[T]])
+  extension [T[_,_]] (tfunction: F[Expr[TypeLevel, T[__, __]]])
     @scala.annotation.targetName("app2T")
-    def apply[A, B](fta: F[Term.TypeLevel[A]])(ftb: F[Term.TypeLevel[B]]): F[Term.TypeLevel[T[A, B]]]
+    def apply[A, B](fta: F[Expr[TypeLevel, A]])(ftb: F[Expr[TypeLevel, B]]): F[Expr[TypeLevel, T[A, B]]]
 
-  extension [A, B] (function: F[Term.ValueLevel[A => B]])
+  extension [A, B] (function: F[Expr[ValueLevel, A => B]])
     @scala.annotation.targetName("app1V")
-    def apply(args: F[Term.ValueLevel[A]]): F[Term.ValueLevel[B]]
+    def apply(args: F[Expr[ValueLevel, A]]): F[Expr[ValueLevel, B]]
 
 object Applications:
 
   trait Mixins extends Applications[[A] =>> StateT[ErrorF, List[Statement], A]]:
 
-    extension [T[_]] (tfunction: StateT[ErrorF, List[Statement], Term.TypeLevel[T[__]]])
+    extension [T[_]] (tfunction: StateT[ErrorF, List[Statement], Expr[TypeLevel, T[__]]])
       @scala.annotation.targetName("app1T")
-      def apply[A](targs: StateT[ErrorF, List[Statement], Term.TypeLevel[A]]): StateT[ErrorF, List[Statement], Term.TypeLevel[T[A]]] =
+      def apply[A](targs: StateT[ErrorF, List[Statement], Expr[TypeLevel, A]]): StateT[ErrorF, List[Statement], Expr[TypeLevel, T[A]]] =
         for
           f <- tfunction
           a <- targs
-        yield Term.TypeLevel.App1[T, A](f, a)
+        yield Expr.BuiltInType(Term.TypeLevel.App1[T, A](f, a))
 
-    extension [T[_,_]] (tfunction: StateT[ErrorF, List[Statement], Term.TypeLevel.Lam2[T]])
+    extension [T[_,_]] (tfunction: StateT[ErrorF, List[Statement], Expr[TypeLevel, T[__, __]]])
       @scala.annotation.targetName("app2T")
-      def apply[A, B](fta: StateT[ErrorF, List[Statement], Term.TypeLevel[A]])(ftb: StateT[ErrorF, List[Statement], Term.TypeLevel[B]]): StateT[ErrorF, List[Statement], Term.TypeLevel[T[A, B]]] =
+      def apply[A, B](fta: StateT[ErrorF, List[Statement], Expr[TypeLevel, A]])(ftb: StateT[ErrorF, List[Statement], Expr[TypeLevel, B]]): StateT[ErrorF, List[Statement], Expr[TypeLevel, T[A, B]]] =
         for
           f <- tfunction
           a <- fta
           b <- ftb
-        yield Term.TypeLevel.App2[T, A, B](f, a, b)
+        yield Expr.BuiltInType(Term.TypeLevel.App2[T, A, B](f, a, b))
 
-    extension [A, B] (function: StateT[ErrorF, List[Statement], Term.ValueLevel[A => B]])
+    extension [A, B] (function: StateT[ErrorF, List[Statement], Expr[ValueLevel, A => B]])
       @scala.annotation.targetName("app1V")
-      def apply(args: StateT[ErrorF, List[Statement], Term.ValueLevel[A]]): StateT[ErrorF, List[Statement], Term.ValueLevel[B]] =
+      def apply(args: StateT[ErrorF, List[Statement], Expr[ValueLevel, A]]): StateT[ErrorF, List[Statement], Expr[ValueLevel, B]] =
         for
           f <- function
           a <- args
-        yield Term.ValueLevel.App1[A, B](f, a)
+        yield Expr.BuiltInValue(Term.ValueLevel.App1[A, B](f, a))

--- a/modules/scala/src/main/scala/dc10/scala/ctx/predef/Applications.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ctx/predef/Applications.scala
@@ -2,9 +2,9 @@ package dc10.scala.ctx.predef
 
 import cats.implicits.*
 import cats.data.StateT
-import dc10.scala.ast.Binding.Term
-import dc10.scala.ast.Binding.Term.TypeLevel.__
-import dc10.scala.ast.Binding.Term.{TypeLevel, ValueLevel}
+import dc10.scala.ast.Symbol.Term
+import dc10.scala.ast.Symbol.Term.TypeLevel.__
+import dc10.scala.ast.Symbol.Term.{TypeLevel, ValueLevel}
 import dc10.scala.ast.Statement
 import dc10.scala.ast.Statement.Expr
 import dc10.scala.ctx.ErrorF

--- a/modules/scala/src/main/scala/dc10/scala/ctx/predef/Functions.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ctx/predef/Functions.scala
@@ -2,9 +2,9 @@ package dc10.scala.ctx.predef
 
 import cats.implicits.*
 import cats.data.StateT
-import dc10.scala.ast.Binding.Term
-import dc10.scala.ast.Binding.Term.{TypeLevel, ValueLevel}
-import dc10.scala.ast.Binding.Term.ValueLevel.Var.UserDefinedValue
+import dc10.scala.ast.Symbol.Term
+import dc10.scala.ast.Symbol.Term.{TypeLevel, ValueLevel}
+import dc10.scala.ast.Symbol.Term.ValueLevel.Var.UserDefinedValue
 import dc10.scala.ast.Statement
 import dc10.scala.ast.Statement.Expr
 import dc10.scala.ctx.ErrorF

--- a/modules/scala/src/main/scala/dc10/scala/ctx/predef/Functions.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ctx/predef/Functions.scala
@@ -2,45 +2,47 @@ package dc10.scala.ctx.predef
 
 import cats.implicits.*
 import cats.data.StateT
-import dc10.scala.ast.Binding
 import dc10.scala.ast.Binding.Term
+import dc10.scala.ast.Binding.Term.{TypeLevel, ValueLevel}
+import dc10.scala.ast.Binding.Term.ValueLevel.Var.UserDefinedValue
 import dc10.scala.ast.Statement
+import dc10.scala.ast.Statement.Expr
 import dc10.scala.ctx.ErrorF
 
 trait Functions[F[_]]:
 
-  extension [A, B] (domain: F[Term.TypeLevel[A]])
+  extension [A, B] (domain: F[Expr[TypeLevel, A]])
     @scala.annotation.targetName("fun1T")
-    def ==>(codomain: F[Term.TypeLevel[B]]): F[Term.TypeLevel[A => B]]
+    def ==>(codomain: F[Expr[TypeLevel, B]]): F[Expr[TypeLevel, A => B]]
 
-  extension [A, B] (fa: F[Term.ValueLevel.Var.UserDefinedValue[A]])
+  extension [A, B] (fa: F[Expr[UserDefinedValue, A]])
     @scala.annotation.targetName("fun1V")
-    def ==>(f: Term.ValueLevel[A] => F[Term.ValueLevel[B]]): F[Term.ValueLevel[A => B]]
+    def ==>(f: Expr[ValueLevel, A] => F[Expr[ValueLevel, B]]): F[Expr[ValueLevel, A => B]]
 
 object Functions:
 
   trait Mixins extends Functions[[A] =>> StateT[ErrorF, List[Statement], A]]:
  
-    extension [A, B] (domain: StateT[ErrorF, List[Statement], Term.TypeLevel[A]])
+    extension [A, B] (domain: StateT[ErrorF, List[Statement], Expr[TypeLevel, A]])
       @scala.annotation.targetName("fun1T")
       def ==>(
-        codomain: StateT[ErrorF, List[Statement], Term.TypeLevel[B]]
-      ): StateT[ErrorF, List[Statement], Term.TypeLevel[A => B]] =
+        codomain: StateT[ErrorF, List[Statement], Expr[TypeLevel, B]]
+      ): StateT[ErrorF, List[Statement], Expr[TypeLevel, A => B]] =
         for
           a <- domain
           b <- codomain
-          v <- StateT.pure(Term.TypeLevel.App2(Term.TypeLevel.Var.Function1Type, a, b))
+          v <- StateT.pure(Expr.BuiltInType(Term.TypeLevel.App2(Expr.BuiltInType(Term.TypeLevel.Var.Function1Type), a, b)))
         yield v
 
-    extension [A, B] (fa: StateT[ErrorF, List[Statement], Term.ValueLevel.Var.UserDefinedValue[A]])
+    extension [A, B] (fa: StateT[ErrorF, List[Statement], Expr[UserDefinedValue, A]])
       @scala.annotation.targetName("fun1V")
       def ==>(
-        f: Term.ValueLevel[A] => StateT[ErrorF, List[Statement], Term.ValueLevel[B]]
-      ): StateT[ErrorF, List[Statement], Term.ValueLevel[A => B]] =
+        f: Expr[ValueLevel, A] => StateT[ErrorF, List[Statement], Expr[ValueLevel, B]]
+      ): StateT[ErrorF, List[Statement], Expr[ValueLevel, A => B]] =
         for
           a <- StateT.liftF(fa.runEmptyA)
           b <- f(a)
           v <- StateT.pure(Term.ValueLevel.Lam1(a, b))
-        yield v
+        yield Expr.BuiltInValue(v)
 
         

--- a/modules/scala/src/main/scala/dc10/scala/ctx/predef/Variables.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ctx/predef/Variables.scala
@@ -1,18 +1,19 @@
 package dc10.scala.ctx.predef
 
 import cats.data.StateT
-import dc10.scala.ast.Binding
 import dc10.scala.ast.Binding.Term
+import dc10.scala.ast.Binding.Term.{TypeLevel, ValueLevel}
+import dc10.scala.ast.Binding.Term.ValueLevel.Var.UserDefinedValue
 import dc10.scala.ast.Statement
-import dc10.scala.ast.Statement.ValDef
+import dc10.scala.ast.Statement.{ValDef, Expr}
 import dc10.scala.ctx.ErrorF
 import dc10.scala.ctx.ext
 import org.tpolecat.sourcepos.SourcePos
 
 trait Variables[F[_]]:
-  def VAL[T](nme: String, tpe: F[Term.TypeLevel[T]])(using sp: SourcePos): F[Term.ValueLevel.Var.UserDefinedValue[T]]
-  def VAL[T](nme: String, tpe: F[Term.TypeLevel[T]])(impl: F[Term.ValueLevel[T]])(using sp: SourcePos): F[Term.ValueLevel.Var.UserDefinedValue[T]]
-  given refV[T]: Conversion[Term.ValueLevel[T], F[Term.ValueLevel[T]]]
+  def VAL[T](nme: String, tpe: F[Expr[TypeLevel, T]])(using sp: SourcePos): F[Expr[UserDefinedValue, T]]
+  def VAL[T](nme: String, tpe: F[Expr[TypeLevel, T]])(impl: F[Expr[ValueLevel, T]])(using sp: SourcePos): F[Expr[UserDefinedValue, T]]
+  given refV[T]: Conversion[Expr[ValueLevel, T], F[Expr[ValueLevel, T]]]
 
 object Variables:
 
@@ -20,34 +21,35 @@ object Variables:
 
     def VAL[T](
       nme: String,
-      tpe: StateT[ErrorF, List[Statement], Term.TypeLevel[T]]
+      tpe: StateT[ErrorF, List[Statement], Expr[TypeLevel, T]]
     )(
       using sp: SourcePos
-    ): StateT[ErrorF, List[Statement], Term.ValueLevel.Var.UserDefinedValue[T]] =
+    ): StateT[ErrorF, List[Statement], Expr[UserDefinedValue, T]] =
       for
         t <- tpe
-        v <- StateT.pure[ErrorF, List[Statement], Term.ValueLevel.Var.UserDefinedValue[T]](
-          Term.ValueLevel.Var.UserDefinedValue(nme, t, None))
+        v <- StateT.pure[ErrorF, List[Statement], Expr[UserDefinedValue, T]](
+          Expr.UserValue(Term.ValueLevel.Var.UserDefinedValue(nme, t, None)))
         d <- StateT.pure[ErrorF, List[Statement], ValDef](ValDef(v)(0))
         _ <- StateT.modifyF[ErrorF, List[Statement]](ctx => ctx.ext(d))
       yield v
 
     def VAL[T](
       nme: String,
-      tpe: StateT[ErrorF, List[Statement], Term.TypeLevel[T]]
+      tpe: StateT[ErrorF, List[Statement], Expr[TypeLevel, T]]
     )( 
-      impl: StateT[ErrorF, List[Statement], Term.ValueLevel[T]]
-    )(using sp: SourcePos): StateT[ErrorF, List[Statement], Term.ValueLevel.Var.UserDefinedValue[T]] =
+      impl: StateT[ErrorF, List[Statement], Expr[ValueLevel, T]]
+    )(using sp: SourcePos): StateT[ErrorF, List[Statement], Expr[UserDefinedValue, T]] =
       for
         t <- tpe
         i <- impl
-        v <- StateT.pure[ErrorF, List[Statement], Term.ValueLevel.Var.UserDefinedValue[T]](
-          Term.ValueLevel.Var.UserDefinedValue(nme, t, Some(i)))
+        v <- StateT.pure[ErrorF, List[Statement], Expr[UserDefinedValue, T]](
+          Expr.UserValue(Term.ValueLevel.Var.UserDefinedValue(nme, t, Some(i)))
+        )
         d <- StateT.pure[ErrorF, List[Statement], ValDef](ValDef(v)(0))
         _ <- StateT.modifyF[ErrorF, List[Statement]](ctx => ctx.ext(d))
       yield v
 
-    given refV[T]: Conversion[Term.ValueLevel[T], StateT[ErrorF, List[Statement], Term.ValueLevel[T]]] =
-      StateT.pure
+    given refV[T]: Conversion[Expr[ValueLevel, T], StateT[ErrorF, List[Statement], Expr[ValueLevel, T]]] =
+      v => StateT.pure(v)
 
   

--- a/modules/scala/src/main/scala/dc10/scala/ctx/predef/Variables.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ctx/predef/Variables.scala
@@ -1,9 +1,9 @@
 package dc10.scala.ctx.predef
 
 import cats.data.StateT
-import dc10.scala.ast.Binding.Term
-import dc10.scala.ast.Binding.Term.{TypeLevel, ValueLevel}
-import dc10.scala.ast.Binding.Term.ValueLevel.Var.UserDefinedValue
+import dc10.scala.ast.Symbol.Term
+import dc10.scala.ast.Symbol.Term.{TypeLevel, ValueLevel}
+import dc10.scala.ast.Symbol.Term.ValueLevel.Var.UserDefinedValue
 import dc10.scala.ast.Statement
 import dc10.scala.ast.Statement.{ValDef, Expr}
 import dc10.scala.ctx.ErrorF

--- a/modules/scala/src/main/scala/dc10/scala/ctx/predef/datatype/ComplexTypes.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ctx/predef/datatype/ComplexTypes.scala
@@ -2,9 +2,9 @@ package dc10.scala.ctx.predef.datatype
 
 import cats.data.StateT
 import cats.implicits.*
-import dc10.scala.ast.Binding.{CaseClass, Term}
-import dc10.scala.ast.Binding.Term.TypeLevel.__
-import dc10.scala.ast.Binding.Term.ValueLevel
+import dc10.scala.ast.Symbol.{CaseClass, Term}
+import dc10.scala.ast.Symbol.Term.TypeLevel.__
+import dc10.scala.ast.Symbol.Term.ValueLevel
 import dc10.scala.ast.Statement
 import dc10.scala.error.CompileError
 import dc10.scala.ctx.ErrorF

--- a/modules/scala/src/main/scala/dc10/scala/ctx/predef/datatype/PrimitiveTypes.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ctx/predef/datatype/PrimitiveTypes.scala
@@ -1,49 +1,50 @@
 package dc10.scala.ctx.predef.datatype
 
 import cats.data.StateT
-import dc10.scala.ast.Binding
 import dc10.scala.ast.Binding.Term
+import dc10.scala.ast.Binding.Term.ValueLevel
 import dc10.scala.ast.Statement
+import dc10.scala.ast.Statement.Expr
 import dc10.scala.ctx.ErrorF
 
 trait PrimitiveTypes[F[_]]:
 
-  def BOOLEAN: F[Term.TypeLevel[Boolean]]
-  given bLit: Conversion[Boolean, F[Term.ValueLevel[Boolean]]]
+  def BOOLEAN: F[Expr[Term.TypeLevel, Boolean]]
+  given bLit: Conversion[Boolean, F[Expr[ValueLevel, Boolean]]]
   
-  def INT: F[Term.TypeLevel[Int]]
-  given iLit: Conversion[Int, F[Term.ValueLevel[Int]]]
+  def INT: F[Expr[Term.TypeLevel, Int]]
+  given iLit: Conversion[Int, F[Expr[ValueLevel, Int]]]
   
-  def STRING: F[Term.TypeLevel[String]]
-  given sLit: Conversion[String, F[Term.ValueLevel[String]]]
+  def STRING: F[Expr[Term.TypeLevel, String]]
+  given sLit: Conversion[String, F[Expr[ValueLevel, String]]]
   
 object PrimitiveTypes:
 
   trait Mixins extends PrimitiveTypes[[A] =>> StateT[ErrorF, List[Statement], A]]:
 
-    def BOOLEAN: StateT[ErrorF, List[Statement], Term.TypeLevel[Boolean]] =
-      StateT.pure(Term.TypeLevel.Var.BooleanType)
+    def BOOLEAN: StateT[ErrorF, List[Statement], Expr[Term.TypeLevel, Boolean]] =
+      StateT.pure(Expr.BuiltInType(Term.TypeLevel.Var.BooleanType))
       
     given bLit: Conversion[
       Boolean,
-      StateT[ErrorF, List[Statement], Term.ValueLevel[Boolean]]
+      StateT[ErrorF, List[Statement], Expr[ValueLevel, Boolean]]
     ] =
-      v => StateT.pure(Term.ValueLevel.Var.BooleanLiteral(v))
+      v => StateT.pure(Expr.BuiltInValue(Term.ValueLevel.Var.BooleanLiteral(v)))
 
-    def INT: StateT[ErrorF, List[Statement], Term.TypeLevel[Int]] =
-      StateT.pure(Term.TypeLevel.Var.IntType)
+    def INT: StateT[ErrorF, List[Statement], Expr[Term.TypeLevel, Int]] =
+      StateT.pure(Expr.BuiltInType(Term.TypeLevel.Var.IntType))
 
     given iLit: Conversion[
       Int,
-      StateT[ErrorF, List[Statement], Term.ValueLevel[Int]]
+      StateT[ErrorF, List[Statement], Expr[ValueLevel, Int]]
     ] =
-      v => StateT.pure(Term.ValueLevel.Var.IntLiteral(v))
+      v => StateT.pure(Expr.BuiltInValue(Term.ValueLevel.Var.IntLiteral(v)))
 
-    def STRING: StateT[ErrorF, List[Statement], Term.TypeLevel[String]] =
-      StateT.pure(Term.TypeLevel.Var.StringType)
+    def STRING: StateT[ErrorF, List[Statement], Expr[Term.TypeLevel, String]] =
+      StateT.pure(Expr.BuiltInType(Term.TypeLevel.Var.StringType))
     
     given sLit: Conversion[
       String,
-      StateT[ErrorF, List[Statement], Term.ValueLevel[String]]
+      StateT[ErrorF, List[Statement], Expr[ValueLevel, String]]
     ] =
-      v => StateT.pure(Term.ValueLevel.Var.StringLiteral(v))
+      v => StateT.pure(Expr.BuiltInValue(Term.ValueLevel.Var.StringLiteral(v)))

--- a/modules/scala/src/main/scala/dc10/scala/ctx/predef/datatype/PrimitiveTypes.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ctx/predef/datatype/PrimitiveTypes.scala
@@ -1,8 +1,8 @@
 package dc10.scala.ctx.predef.datatype
 
 import cats.data.StateT
-import dc10.scala.ast.Binding.Term
-import dc10.scala.ast.Binding.Term.ValueLevel
+import dc10.scala.ast.Symbol.Term
+import dc10.scala.ast.Symbol.Term.ValueLevel
 import dc10.scala.ast.Statement
 import dc10.scala.ast.Statement.Expr
 import dc10.scala.ctx.ErrorF

--- a/modules/scala/src/main/scala/dc10/scala/ctx/predef/file/Files.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ctx/predef/file/Files.scala
@@ -1,7 +1,7 @@
 package dc10.scala.ctx.predef.file
 
 import cats.data.StateT
-import dc10.scala.ast.Binding.Package
+import dc10.scala.ast.Symbol.Package
 import dc10.scala.ast.Statement
 import dc10.scala.ctx.{ErrorF, ext}
 import dc10.scala.file.ScalaFile

--- a/modules/scala/src/main/scala/dc10/scala/ctx/predef/file/Files.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ctx/predef/file/Files.scala
@@ -1,7 +1,6 @@
 package dc10.scala.ctx.predef.file
 
 import cats.data.StateT
-import dc10.scala.ast.Binding
 import dc10.scala.ast.Binding.Package
 import dc10.scala.ast.Statement
 import dc10.scala.ctx.{ErrorF, ext}

--- a/modules/scala/src/main/scala/dc10/scala/version/package.scala
+++ b/modules/scala/src/main/scala/dc10/scala/version/package.scala
@@ -1,8 +1,8 @@
 package dc10.scala.version
 
 import dc10.compile.Renderer
-import dc10.scala.ast.Binding.Package.{Basic, Empty}
-import dc10.scala.ast.Binding.Term
+import dc10.scala.ast.Symbol.Package.{Basic, Empty}
+import dc10.scala.ast.Symbol.Term
 import dc10.scala.ast.Statement
 import dc10.scala.ast.Statement.{CaseClassDef, PackageDef, ValDef, Expr}
 import dc10.scala.ast.Statement.Expr.{BuiltInType, BuiltInValue, UserType, UserValue}

--- a/modules/scala/src/main/scala/dc10/scala/version/package.scala
+++ b/modules/scala/src/main/scala/dc10/scala/version/package.scala
@@ -1,19 +1,18 @@
 package dc10.scala.version
 
 import dc10.compile.Renderer
-import dc10.scala.ast.Binding
-import dc10.scala.ast.Binding.{Package, Term}
 import dc10.scala.ast.Binding.Package.{Basic, Empty}
+import dc10.scala.ast.Binding.Term
 import dc10.scala.ast.Statement
-import dc10.scala.ast.Statement.{RecordDef, PackageDef, ValDef}
+import dc10.scala.ast.Statement.{CaseClassDef, PackageDef, ValDef, Expr}
+import dc10.scala.ast.Statement.Expr.{BuiltInType, BuiltInValue, UserType, UserValue}
 import dc10.scala.error.CompileError
 
-  
 given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
   new Renderer["scala-3.3.0", CompileError, List[Statement]]:
 
     def render(input: List[Statement]): String = input.map(stmt => stmt match
-      case d@RecordDef(_, _) =>
+      case d@CaseClassDef(_, _) =>
         s"case class ${d.caseclass.nme}(${render(d.caseclass.fields).mkString})"
       case d@Statement.ObjectDef(_, _, _) =>
         ???
@@ -21,15 +20,23 @@ given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
         d.pkg match
           case Basic(nme, nst) => s"package ${nme}\n\n"
           case Empty(ms) => render(ms)
-      case d@ValDef(_, _) =>
+      case d@ValDef(_, _) => 
         d.value match
-          case Term.ValueLevel.Var.UserDefinedValue(n, t, mi) =>
-            mi.fold(
-              s"val ${n}: ${renderType(t)}"
+          case UserValue(value) =>
+           value.impl.fold(
+              s"val ${value.nme}: ${renderExpr(value.tpe)}"
             )(
               i =>
-                s"val ${n}: ${renderType(t)} = ${renderValue(i)}"
+                s"val ${value.nme}: ${renderExpr(value.tpe)} = ${renderExpr(i)}"
             )
+      case BuiltInType(t) => 
+        renderType(t) 
+      case BuiltInValue(v) => 
+        renderValue(v) 
+      case UserType(t) => 
+        renderType(t)
+      case UserValue(v) => 
+        renderValue(v)
     ).mkString("\n")
 
     def renderErrors(errors: List[CompileError]): String =
@@ -37,16 +44,22 @@ given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
 
     override def version: "scala-3.3.0" =
       "scala-3.3.0"
-    
-    // private def renderPackage(pkg: Package): String = pkg match
-    //   case Basic(nme, nst) => s".${nme}${renderPackage(nst.pkg)}"
-    //   case Empty(ms) => render(ms)
 
+    private def renderExpr[F[_], T](expr: Expr[F, T]): String =
+      expr match
+        case BuiltInType(v) =>        
+          renderType(v)
+        case BuiltInValue(v) =>        
+          renderValue(v)
+        case UserType(t) =>
+          renderType(t)
+        case UserValue(v) =>
+          renderValue(v)
     private def renderType[T](tpe: Term.TypeLevel[T]): String =
       tpe match
         // application
-        case Term.TypeLevel.App1(tfun, targ) => s"${renderType(tfun)}[${renderType(targ)}]"
-        case Term.TypeLevel.App2(tfun, ta, tb) => s"${renderType(ta)} ${renderType(tfun)} ${renderType(tb)}"
+        case Term.TypeLevel.App1(tfun, targ) => s"${renderExpr(tfun)}[${renderExpr(targ)}]"
+        case Term.TypeLevel.App2(tfun, ta, tb) => s"${renderExpr(ta)} ${renderExpr(tfun)} ${renderExpr(tb)}"
         // primitive
         case Term.TypeLevel.Var.BooleanType => "Boolean"
         case Term.TypeLevel.Var.IntType => "Int"
@@ -59,11 +72,11 @@ given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
     private def renderValue[T](value: Term.ValueLevel[T]): String =
       value match 
         // application
-        case Term.ValueLevel.App1(f, a) => s"${renderValue(f)}(${renderValue(a)})"
-        case Term.ValueLevel.AppCtor1(t, a) => s"${renderType(t)}(${renderValue(a)})"
-        case Term.ValueLevel.AppVargs(f, as*) => s"${renderValue(f)}(${as.map(a => renderValue(a)).mkString(", ")})"
+        case Term.ValueLevel.App1(f, a) => s"${renderExpr(f)}(${renderExpr(a)})"
+        case Term.ValueLevel.AppCtor1(t, a) => s"${renderExpr(t)}(${renderExpr(a)})"
+        case Term.ValueLevel.AppVargs(f, as*) => s"${renderExpr(f)}(${as.map(a => renderExpr(a)).mkString(", ")})"
         // function
-        case Term.ValueLevel.Lam1(a, b) => s"${renderValue(a)} => ${renderValue(b)}"
+        case Term.ValueLevel.Lam1(a, b) => s"${renderExpr(a)} => ${renderExpr(b)}"
         // primitive
         case Term.ValueLevel.Var.BooleanLiteral(b) => s"$b"
         case Term.ValueLevel.Var.IntLiteral(i) => s"$i"


### PR DESCRIPTION
Statements (expressions and definitions) are intended to represent the introduction of a symbol into a program definition.