### PR TITLE
Functorize terms and add quantities

### DIFF
--- a/modules/compile/src/main/scala/dc10/compile/Config.scala
+++ b/modules/compile/src/main/scala/dc10/compile/Config.scala
@@ -7,6 +7,6 @@ trait Config[V]:
 
 object Config:
   
-  given Config["scala-3.3.0"] =
-    new Config["scala-3.3.0"]:
+  given Config["scala-3.3.1"] =
+    new Config["scala-3.3.1"]:
       def target: Path = Path.of("")

--- a/modules/scala/src/main/scala/dc10/scala/ast/Statement.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ast/Statement.scala
@@ -71,7 +71,7 @@ object Statement:
         def value: Term.Value[T] = v
 
 
-  case class TypeExpr[T](tpe: Term.TypeLevel[T]) extends Statement:
+  case class TypeExpr[T](tpe: Term.Type[T]) extends Statement:
     def indent: Int = 0
     def sp: SourcePos = summon[SourcePos]
 

--- a/modules/scala/src/main/scala/dc10/scala/ast/Symbol.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ast/Symbol.scala
@@ -18,13 +18,14 @@ object Symbol:
 
   object CaseClass:
     def apply[T](
+      q: Option[Long],
       n: String,
       fs: List[Statement.ValDef],
     ): CaseClass[T] =
       new CaseClass[T]:
         type Tpe = T
         def nme = n
-        def tpe: Term.TypeLevel.Var.UserDefinedType[T] = Term.TypeLevel.Var.UserDefinedType[T](n, None)
+        def tpe: Term.TypeLevel.Var.UserDefinedType[T] = Term.TypeLevel.Var.UserDefinedType[T](q, n, None)
         def fields = fs
         def body = Nil
 
@@ -54,37 +55,36 @@ object Symbol:
     ) extends Package
 
   // Term /////////////////////////////////////////////////////////////////////
-  sealed abstract class Term extends Symbol
+  sealed abstract class Term extends Symbol:
+    def qnt: Option[Long]
 
   object Term:
 
     sealed trait TypeLevel[T] extends Term
     object TypeLevel:
       type __
-      case class App1[T[_], A](tfun: TypeLevel[T[__]], targ: TypeLevel[A]) extends TypeLevel[T[A]]
-      case class App2[T[_,_], A, B](tfun: TypeLevel[T[__,__]], ta: TypeLevel[A], tb: TypeLevel[B]) extends TypeLevel[T[A, B]]
-      sealed trait Lam1[F[_]] extends TypeLevel[F[__]]
-      sealed trait Lam2[F[_,_]] extends TypeLevel[F[__,__]]
+      case class App1[T[_], A](qnt: Option[Long], tfun: TypeLevel[T[__]], targ: TypeLevel[A]) extends TypeLevel[T[A]]
+      case class App2[T[_,_], A, B](qnt: Option[Long], tfun: TypeLevel[T[__,__]], ta: TypeLevel[A], tb: TypeLevel[B]) extends TypeLevel[T[A, B]]
       sealed abstract class Var[T] extends TypeLevel[T]
       object Var:
-        case object BooleanType extends Var[Boolean]
-        case object IntType extends Var[Int]
-        case object StringType extends Var[String]
-        case object Function1Type extends Var[__ => __]
-        case object ListType extends Var[List[__]]
-        case class UserDefinedType[T](nme: String, impl: Option[TypeLevel[T]]) extends Var[T]
+        case class BooleanType(qnt: Option[Long]) extends Var[Boolean]
+        case class IntType(qnt: Option[Long]) extends Var[Int]
+        case class StringType(qnt: Option[Long]) extends Var[String]
+        case class Function1Type(qnt: Option[Long]) extends Var[__ => __]
+        case class ListType(qnt: Option[Long]) extends Var[List[__]]
+        case class UserDefinedType[T](qnt: Option[Long], nme: String, impl: Option[TypeLevel[T]]) extends Var[T]
         
     type Value[T] = Cofree[[X] =>> ValueLevel[T, X], Unit]
     sealed trait ValueLevel[T, X] extends Term
     object ValueLevel:
-      case class App1[A, B, X](fun: Value[A => B], arg: Value[A]) extends Term.ValueLevel[B, X]
-      case class AppCtor1[T, A, X](tpe: TypeLevel[T], arg: Value[A]) extends Term.ValueLevel[T, X]
-      case class AppVargs[A, B, X](fun: Value[List[A] => B], vargs: Value[A]*) extends Term.ValueLevel[B, X]
-      case class Lam1[A, B, X](a: Value[A], b: Value[B]) extends Term.ValueLevel[A => B, X]
+      case class App1[A, B, X](qnt: Option[Long], fun: Value[A => B], arg: Value[A]) extends Term.ValueLevel[B, X]
+      case class AppCtor1[T, A, X](qnt: Option[Long], tpe: TypeLevel[T], arg: Value[A]) extends Term.ValueLevel[T, X]
+      case class AppVargs[A, B, X](qnt: Option[Long], fun: Value[List[A] => B], vargs: Value[A]*) extends Term.ValueLevel[B, X]
+      case class Lam1[A, B, X](qnt: Option[Long], a: Value[A], b: Value[B]) extends Term.ValueLevel[A => B, X]
       sealed abstract class Var[T, X] extends Term.ValueLevel[T, X]
       object Var:
-        case class BooleanLiteral[X](b: Boolean) extends Var[Boolean, X]
-        case class IntLiteral[X](i: Int) extends Var[Int, X]
-        case class StringLiteral[X](s: String) extends Var[String, X]
-        case class ListCtor[A, X]() extends Var[List[A] => List[A], X]
-        case class UserDefinedValue[T, X](nme: String, tpe: TypeLevel[T], impl: Option[Value[T]]) extends Var[T, X]
+        case class BooleanLiteral[X](qnt: Option[Long], b: Boolean) extends Var[Boolean, X]
+        case class IntLiteral[X](qnt: Option[Long], i: Int) extends Var[Int, X]
+        case class StringLiteral[X](qnt: Option[Long], s: String) extends Var[String, X]
+        case class ListCtor[A, X](qnt: Option[Long]) extends Var[List[A] => List[A], X]
+        case class UserDefinedValue[T, X](qnt: Option[Long], nme: String, tpe: TypeLevel[T], impl: Option[Value[T]]) extends Var[T, X]

--- a/modules/scala/src/main/scala/dc10/scala/ast/Symbol.scala
+++ b/modules/scala/src/main/scala/dc10/scala/ast/Symbol.scala
@@ -1,5 +1,6 @@
 package dc10.scala.ast
 
+import cats.Eval
 import cats.free.Cofree
 import dc10.scala.ast.Symbol.Term.{TypeLevel, ValueLevel}
 import java.nio.file.Path
@@ -12,7 +13,7 @@ object Symbol:
   sealed abstract class CaseClass[T] extends Symbol:
     type Tpe = T
     def nme: String
-    def tpe: Term.TypeLevel.Var.UserDefinedType[T]
+    def tpe: Term.Type[T]
     def fields: List[Statement.ValDef]
     def body: List[Statement]
 
@@ -25,7 +26,7 @@ object Symbol:
       new CaseClass[T]:
         type Tpe = T
         def nme = n
-        def tpe: Term.TypeLevel.Var.UserDefinedType[T] = Term.TypeLevel.Var.UserDefinedType[T](q, n, None)
+        def tpe: Term.Type[T] = Cofree((), Eval.now(Term.TypeLevel.Var.UserDefinedType(q, n, None)))
         def fields = fs
         def body = Nil
 
@@ -60,25 +61,26 @@ object Symbol:
 
   object Term:
 
-    sealed trait TypeLevel[T] extends Term
+    type Type[T] = Cofree[[X] =>> TypeLevel[T, X], Unit]
+    sealed trait TypeLevel[T, X] extends Term
     object TypeLevel:
       type __
-      case class App1[T[_], A](qnt: Option[Long], tfun: TypeLevel[T[__]], targ: TypeLevel[A]) extends TypeLevel[T[A]]
-      case class App2[T[_,_], A, B](qnt: Option[Long], tfun: TypeLevel[T[__,__]], ta: TypeLevel[A], tb: TypeLevel[B]) extends TypeLevel[T[A, B]]
-      sealed abstract class Var[T] extends TypeLevel[T]
+      case class App1[T[_], A, X](qnt: Option[Long], tfun: Type[T[__]], targ: Type[A]) extends TypeLevel[T[A], X]
+      case class App2[T[_,_], A, B, X](qnt: Option[Long], tfun: Type[T[__,__]], ta: Type[A], tb: Type[B]) extends TypeLevel[T[A, B], X]
+      sealed abstract class Var[T, X] extends TypeLevel[T, X]
       object Var:
-        case class BooleanType(qnt: Option[Long]) extends Var[Boolean]
-        case class IntType(qnt: Option[Long]) extends Var[Int]
-        case class StringType(qnt: Option[Long]) extends Var[String]
-        case class Function1Type(qnt: Option[Long]) extends Var[__ => __]
-        case class ListType(qnt: Option[Long]) extends Var[List[__]]
-        case class UserDefinedType[T](qnt: Option[Long], nme: String, impl: Option[TypeLevel[T]]) extends Var[T]
+        case class BooleanType[X](qnt: Option[Long]) extends Var[Boolean, X]
+        case class IntType[X](qnt: Option[Long]) extends Var[Int, X]
+        case class StringType[X](qnt: Option[Long]) extends Var[String, X]
+        case class Function1Type[X](qnt: Option[Long]) extends Var[__ => __, X]
+        case class ListType[X](qnt: Option[Long]) extends Var[List[__], X]
+        case class UserDefinedType[T, X](qnt: Option[Long], nme: String, impl: Option[Type[T]]) extends Var[T, X]
         
     type Value[T] = Cofree[[X] =>> ValueLevel[T, X], Unit]
     sealed trait ValueLevel[T, X] extends Term
     object ValueLevel:
       case class App1[A, B, X](qnt: Option[Long], fun: Value[A => B], arg: Value[A]) extends Term.ValueLevel[B, X]
-      case class AppCtor1[T, A, X](qnt: Option[Long], tpe: TypeLevel[T], arg: Value[A]) extends Term.ValueLevel[T, X]
+      case class AppCtor1[T, A, X](qnt: Option[Long], tpe: Type[T], arg: Value[A]) extends Term.ValueLevel[T, X]
       case class AppVargs[A, B, X](qnt: Option[Long], fun: Value[List[A] => B], vargs: Value[A]*) extends Term.ValueLevel[B, X]
       case class Lam1[A, B, X](qnt: Option[Long], a: Value[A], b: Value[B]) extends Term.ValueLevel[A => B, X]
       sealed abstract class Var[T, X] extends Term.ValueLevel[T, X]
@@ -87,4 +89,4 @@ object Symbol:
         case class IntLiteral[X](qnt: Option[Long], i: Int) extends Var[Int, X]
         case class StringLiteral[X](qnt: Option[Long], s: String) extends Var[String, X]
         case class ListCtor[A, X](qnt: Option[Long]) extends Var[List[A] => List[A], X]
-        case class UserDefinedValue[T, X](qnt: Option[Long], nme: String, tpe: TypeLevel[T], impl: Option[Value[T]]) extends Var[T, X]
+        case class UserDefinedValue[T, X](qnt: Option[Long], nme: String, tpe: Type[T], impl: Option[Value[T]]) extends Var[T, X]

--- a/modules/scala/src/main/scala/dc10/scala/predef/Applications.scala
+++ b/modules/scala/src/main/scala/dc10/scala/predef/Applications.scala
@@ -35,7 +35,7 @@ object Applications:
         for
           f <- tfunction
           a <- targs
-        yield TypeExpr(Term.TypeLevel.App1[T, A](f.tpe, a.tpe))
+        yield TypeExpr(Term.TypeLevel.App1[T, A](None, f.tpe, a.tpe))
 
     extension [T[_,_]] (tfunction: StateT[ErrorF, List[Statement], TypeExpr[T[__, __]]])
       @scala.annotation.targetName("app2T")
@@ -44,7 +44,7 @@ object Applications:
           f <- tfunction
           a <- fta
           b <- ftb
-        yield TypeExpr(Term.TypeLevel.App2[T, A, B](f.tpe, a.tpe, b.tpe))
+        yield TypeExpr(Term.TypeLevel.App2[T, A, B](None, f.tpe, a.tpe, b.tpe))
 
     extension [A, B] (function: StateT[ErrorF, List[Statement], ValueExpr[A => B]])
       @scala.annotation.targetName("app1V")
@@ -52,4 +52,4 @@ object Applications:
         for
           f <- function
           a <- args
-        yield ValueExpr(Cofree((), Eval.now(Term.ValueLevel.App1(f.value, a.value))))
+        yield ValueExpr(Cofree((), Eval.now(Term.ValueLevel.App1(None, f.value, a.value))))

--- a/modules/scala/src/main/scala/dc10/scala/predef/Applications.scala
+++ b/modules/scala/src/main/scala/dc10/scala/predef/Applications.scala
@@ -35,7 +35,7 @@ object Applications:
         for
           f <- tfunction
           a <- targs
-        yield TypeExpr(Term.TypeLevel.App1[T, A](None, f.tpe, a.tpe))
+        yield TypeExpr(Cofree((), Eval.now(Term.TypeLevel.App1(None, f.tpe, a.tpe))))
 
     extension [T[_,_]] (tfunction: StateT[ErrorF, List[Statement], TypeExpr[T[__, __]]])
       @scala.annotation.targetName("app2T")
@@ -44,7 +44,7 @@ object Applications:
           f <- tfunction
           a <- fta
           b <- ftb
-        yield TypeExpr(Term.TypeLevel.App2[T, A, B](None, f.tpe, a.tpe, b.tpe))
+        yield TypeExpr(Cofree((), Eval.now(Term.TypeLevel.App2(None, f.tpe, a.tpe, b.tpe))))
 
     extension [A, B] (function: StateT[ErrorF, List[Statement], ValueExpr[A => B]])
       @scala.annotation.targetName("app1V")

--- a/modules/scala/src/main/scala/dc10/scala/predef/Functions.scala
+++ b/modules/scala/src/main/scala/dc10/scala/predef/Functions.scala
@@ -7,7 +7,7 @@ import cats.free.Cofree
 import dc10.scala.ast.Statement
 import dc10.scala.ast.Statement.{TypeExpr, ValueExpr}
 import dc10.scala.ast.Symbol.Term
-import dc10.scala.ast.Symbol.Term.{TypeLevel, ValueLevel, Value}
+import dc10.scala.ast.Symbol.Term.{Type, Value}
 import dc10.scala.error.ErrorF
 
 trait Functions[F[_]]:
@@ -32,7 +32,7 @@ object Functions:
         for
           a <- domain
           b <- codomain
-          v <- StateT.pure(Term.TypeLevel.App2(None, Term.TypeLevel.Var.Function1Type(None), a.tpe, b.tpe))
+          v <- StateT.pure[ErrorF, List[Statement], Type[A => B]](Cofree((), Eval.now(Term.TypeLevel.App2(None, Cofree((), Eval.now(Term.TypeLevel.Var.Function1Type(None))), a.tpe, b.tpe))))
         yield TypeExpr(v)
 
     extension [A, B] (fa: StateT[ErrorF, List[Statement], ValueExpr[A]])

--- a/modules/scala/src/main/scala/dc10/scala/predef/Functions.scala
+++ b/modules/scala/src/main/scala/dc10/scala/predef/Functions.scala
@@ -32,7 +32,7 @@ object Functions:
         for
           a <- domain
           b <- codomain
-          v <- StateT.pure(Term.TypeLevel.App2(Term.TypeLevel.Var.Function1Type, a.tpe, b.tpe))
+          v <- StateT.pure(Term.TypeLevel.App2(None, Term.TypeLevel.Var.Function1Type(None), a.tpe, b.tpe))
         yield TypeExpr(v)
 
     extension [A, B] (fa: StateT[ErrorF, List[Statement], ValueExpr[A]])
@@ -43,7 +43,7 @@ object Functions:
         for
           a <- StateT.liftF(fa.runEmptyA)
           b <- f(a)
-          v <- StateT.pure[ErrorF, List[Statement], Value[A => B]](Cofree((), Eval.now(Term.ValueLevel.Lam1(a.value, b.value))))
+          v <- StateT.pure[ErrorF, List[Statement], Value[A => B]](Cofree((), Eval.now(Term.ValueLevel.Lam1(None, a.value, b.value))))
         yield ValueExpr(v)
 
         

--- a/modules/scala/src/main/scala/dc10/scala/predef/Variables.scala
+++ b/modules/scala/src/main/scala/dc10/scala/predef/Variables.scala
@@ -27,7 +27,7 @@ object Variables:
     ): StateT[ErrorF, List[Statement], ValueExpr[T]] =
       for
         t <- tpe
-        v <- StateT.pure[ErrorF, List[Statement], Term.Value[T]](Cofree((), Eval.now(Term.ValueLevel.Var.UserDefinedValue(nme, t.tpe, None))))
+        v <- StateT.pure[ErrorF, List[Statement], Term.Value[T]](Cofree((), Eval.now(Term.ValueLevel.Var.UserDefinedValue(None, nme, t.tpe, None))))
         d <- StateT.pure[ErrorF, List[Statement], ValDef](ValDef(v)(0))
         _ <- StateT.modifyF[ErrorF, List[Statement]](ctx => ctx.ext(d))
       yield ValueExpr(v)
@@ -41,7 +41,7 @@ object Variables:
       for
         t <- tpe
         i <- impl
-        v <- StateT.pure[ErrorF, List[Statement], Term.Value[T]](Cofree((), Eval.now(Term.ValueLevel.Var.UserDefinedValue(nme, t.tpe, Some(i.value)))))
+        v <- StateT.pure[ErrorF, List[Statement], Term.Value[T]](Cofree((), Eval.now(Term.ValueLevel.Var.UserDefinedValue(None, nme, t.tpe, Some(i.value)))))
         d <- StateT.pure[ErrorF, List[Statement], ValDef](ValDef(v)(0))
         _ <- StateT.modifyF[ErrorF, List[Statement]](ctx => ctx.ext(d))
       yield ValueExpr(v)

--- a/modules/scala/src/main/scala/dc10/scala/predef/datatype/ComplexTypes.scala
+++ b/modules/scala/src/main/scala/dc10/scala/predef/datatype/ComplexTypes.scala
@@ -47,31 +47,31 @@ object ComplexTypes:
             case d@Statement.ValueExpr(_)      => Left(scala.List(IdentifierStatementExpected(d)))
           )
         )
-        c <- StateT.pure(CaseClass[T](name, fs))
+        c <- StateT.pure(CaseClass[T](None, name, fs))
         f <- StateT.pure[ErrorF, List[Statement], ValueExpr[A => T]](ValueExpr(
-          Cofree((), Eval.now(Term.ValueLevel.Lam1(a.value, Cofree((), Eval.now(Term.ValueLevel.AppCtor1(c.tpe, a.value))))))))
+          Cofree((), Eval.now(Term.ValueLevel.Lam1(None, a.value, Cofree((), Eval.now(Term.ValueLevel.AppCtor1(None, c.tpe, a.value))))))))
         v <- StateT.liftF[ErrorF, List[Statement], ValueExpr[A => T]](
           a.value.tail.value match
-            case App1(_, _)          => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
-            case AppCtor1(_, _)      => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
-            case AppVargs(_, vargs*) => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
-            case Lam1(_, _)          => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
-            case BooleanLiteral(_)   => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
-            case IntLiteral(_)       => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
-            case StringLiteral(_)    => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
-            case ListCtor()          => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
-            case UserDefinedValue(nme, tpe, impl) => Right[List[CompileError], Statement.ValueExpr[A => T]](ValueExpr[A => T](
-              Cofree((), Eval.now(Term.ValueLevel.Var.UserDefinedValue(name, Term.TypeLevel.App2(Term.TypeLevel.Var.Function1Type, tpe, c.tpe), Some(f.value))))))
+            case App1(_, _, _)          => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
+            case AppCtor1(_, _, _)      => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
+            case AppVargs(_, _, vargs*) => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
+            case Lam1(_, _, _)          => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
+            case BooleanLiteral(_, _)   => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
+            case IntLiteral(_, _)       => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
+            case StringLiteral(_, _)    => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
+            case ListCtor(_)          => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
+            case UserDefinedValue(qnt, nme, tpe, impl) => Right[List[CompileError], Statement.ValueExpr[A => T]](ValueExpr[A => T](
+              Cofree((), Eval.now(Term.ValueLevel.Var.UserDefinedValue(qnt, name, Term.TypeLevel.App2(None, Term.TypeLevel.Var.Function1Type(None), tpe, c.tpe), Some(f.value))))))
         )
         d <- StateT.pure(Statement.CaseClassDef(c, 0))
         _ <- StateT.modifyF[ErrorF, List[Statement]](ctx => ctx.ext(d))
       yield (TypeExpr(c.tpe), v)
 
     def LIST: StateT[ErrorF, List[Statement], TypeExpr[List[__]]] =
-      StateT.pure(TypeExpr(Term.TypeLevel.Var.ListType))
+      StateT.pure(TypeExpr(Term.TypeLevel.Var.ListType(None)))
       
     def List[A]: StateT[ErrorF, List[Statement], ValueExpr[List[A] => List[A]]] =
-      StateT.pure(ValueExpr(Cofree((), Eval.now(Term.ValueLevel.Var.ListCtor()))))
+      StateT.pure(ValueExpr(Cofree((), Eval.now(Term.ValueLevel.Var.ListCtor(None)))))
     
     extension [A] (list: StateT[ErrorF, List[Statement], ValueExpr[List[A] => List[A]]])
       @scala.annotation.targetName("appVL")
@@ -79,4 +79,4 @@ object ComplexTypes:
         for
           l <- list
           a <- args.toList.sequence
-        yield ValueExpr(Cofree((), Eval.now(Term.ValueLevel.AppVargs(l.value, a.map(arg => arg.value)*))))
+        yield ValueExpr(Cofree((), Eval.now(Term.ValueLevel.AppVargs(None, l.value, a.map(arg => arg.value)*))))

--- a/modules/scala/src/main/scala/dc10/scala/predef/datatype/ComplexTypes.scala
+++ b/modules/scala/src/main/scala/dc10/scala/predef/datatype/ComplexTypes.scala
@@ -61,14 +61,14 @@ object ComplexTypes:
             case StringLiteral(_, _)    => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
             case ListCtor(_)          => Left(scala.List(IdentifierSymbolExpected(a.value.tail.value)))
             case UserDefinedValue(qnt, nme, tpe, impl) => Right[List[CompileError], Statement.ValueExpr[A => T]](ValueExpr[A => T](
-              Cofree((), Eval.now(Term.ValueLevel.Var.UserDefinedValue(qnt, name, Term.TypeLevel.App2(None, Term.TypeLevel.Var.Function1Type(None), tpe, c.tpe), Some(f.value))))))
+              Cofree((), Eval.now(Term.ValueLevel.Var.UserDefinedValue(qnt, name, Cofree((), Eval.now(Term.TypeLevel.App2(None, Cofree((), Eval.now(Term.TypeLevel.Var.Function1Type(None))), tpe, c.tpe))), Some(f.value))))))
         )
         d <- StateT.pure(Statement.CaseClassDef(c, 0))
         _ <- StateT.modifyF[ErrorF, List[Statement]](ctx => ctx.ext(d))
       yield (TypeExpr(c.tpe), v)
 
     def LIST: StateT[ErrorF, List[Statement], TypeExpr[List[__]]] =
-      StateT.pure(TypeExpr(Term.TypeLevel.Var.ListType(None)))
+      StateT.pure(TypeExpr(Cofree((), Eval.now(Term.TypeLevel.Var.ListType(None)))))
       
     def List[A]: StateT[ErrorF, List[Statement], ValueExpr[List[A] => List[A]]] =
       StateT.pure(ValueExpr(Cofree((), Eval.now(Term.ValueLevel.Var.ListCtor(None)))))

--- a/modules/scala/src/main/scala/dc10/scala/predef/datatype/PrimitiveTypes.scala
+++ b/modules/scala/src/main/scala/dc10/scala/predef/datatype/PrimitiveTypes.scala
@@ -25,7 +25,7 @@ object PrimitiveTypes:
   trait Mixins extends PrimitiveTypes[[A] =>> StateT[ErrorF, List[Statement], A]]:
 
     def BOOLEAN: StateT[ErrorF, List[Statement], TypeExpr[Boolean]] =
-      StateT.pure(TypeExpr(Term.TypeLevel.Var.BooleanType(None)))
+      StateT.pure(TypeExpr(Cofree((), Eval.now(Term.TypeLevel.Var.BooleanType(None)))))
       
     given bLit: Conversion[
       Boolean,
@@ -34,7 +34,7 @@ object PrimitiveTypes:
       v => StateT.pure(ValueExpr(Cofree((), Eval.now(Term.ValueLevel.Var.BooleanLiteral(None, v)))))
 
     def INT: StateT[ErrorF, List[Statement], TypeExpr[Int]] =
-      StateT.pure(TypeExpr(Term.TypeLevel.Var.IntType(None)))
+      StateT.pure(TypeExpr(Cofree((), Eval.now(Term.TypeLevel.Var.IntType(None)))))
 
     given iLit: Conversion[
       Int,
@@ -43,7 +43,7 @@ object PrimitiveTypes:
       v => StateT.pure(ValueExpr(Cofree((), Eval.now(Term.ValueLevel.Var.IntLiteral(None, v)))))
 
     def STRING: StateT[ErrorF, List[Statement], TypeExpr[String]] =
-      StateT.pure(TypeExpr(Term.TypeLevel.Var.StringType(None)))
+      StateT.pure(TypeExpr(Cofree((), Eval.now(Term.TypeLevel.Var.StringType(None)))))
     
     given sLit: Conversion[
       String,

--- a/modules/scala/src/main/scala/dc10/scala/predef/datatype/PrimitiveTypes.scala
+++ b/modules/scala/src/main/scala/dc10/scala/predef/datatype/PrimitiveTypes.scala
@@ -25,28 +25,28 @@ object PrimitiveTypes:
   trait Mixins extends PrimitiveTypes[[A] =>> StateT[ErrorF, List[Statement], A]]:
 
     def BOOLEAN: StateT[ErrorF, List[Statement], TypeExpr[Boolean]] =
-      StateT.pure(TypeExpr(Term.TypeLevel.Var.BooleanType))
+      StateT.pure(TypeExpr(Term.TypeLevel.Var.BooleanType(None)))
       
     given bLit: Conversion[
       Boolean,
       StateT[ErrorF, List[Statement], ValueExpr[Boolean]]
     ] =
-      v => StateT.pure(ValueExpr(Cofree((), Eval.now(Term.ValueLevel.Var.BooleanLiteral(v)))))
+      v => StateT.pure(ValueExpr(Cofree((), Eval.now(Term.ValueLevel.Var.BooleanLiteral(None, v)))))
 
     def INT: StateT[ErrorF, List[Statement], TypeExpr[Int]] =
-      StateT.pure(TypeExpr(Term.TypeLevel.Var.IntType))
+      StateT.pure(TypeExpr(Term.TypeLevel.Var.IntType(None)))
 
     given iLit: Conversion[
       Int,
       StateT[ErrorF, List[Statement], ValueExpr[Int]]
     ] =
-      v => StateT.pure(ValueExpr(Cofree((), Eval.now(Term.ValueLevel.Var.IntLiteral(v)))))
+      v => StateT.pure(ValueExpr(Cofree((), Eval.now(Term.ValueLevel.Var.IntLiteral(None, v)))))
 
     def STRING: StateT[ErrorF, List[Statement], TypeExpr[String]] =
-      StateT.pure(TypeExpr(Term.TypeLevel.Var.StringType))
+      StateT.pure(TypeExpr(Term.TypeLevel.Var.StringType(None)))
     
     given sLit: Conversion[
       String,
       StateT[ErrorF, List[Statement], ValueExpr[String]]
     ] =
-      v => StateT.pure(ValueExpr(Cofree((), Eval.now(Term.ValueLevel.Var.StringLiteral(v)))))
+      v => StateT.pure(ValueExpr(Cofree((), Eval.now(Term.ValueLevel.Var.StringLiteral(None, v)))))

--- a/modules/scala/src/main/scala/dc10/scala/version/package.scala
+++ b/modules/scala/src/main/scala/dc10/scala/version/package.scala
@@ -24,10 +24,10 @@ given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
       case d@ValDef(_, _) =>
         d.value.tail.value match
           case UserDefinedValue(_, nme, tpe, impl) =>  impl.fold(
-              s"val ${nme}: ${renderType(tpe)}"
+              s"val ${nme}: ${renderType(tpe.tail.value)}"
             )(
               i =>
-                s"val ${nme}: ${renderType(tpe)} = ${renderValue(i.tail.value)}"
+                s"val ${nme}: ${renderType(tpe.tail.value)} = ${renderValue(i.tail.value)}"
             )
           case Term.ValueLevel.App1(_, _, _) => ""
           case Term.ValueLevel.AppCtor1(_, _, _) => ""
@@ -40,7 +40,7 @@ given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
           case Term.ValueLevel.Var.ListCtor(_) => ""
 
       case TypeExpr(t) => 
-        renderType(t)
+        renderType(t.tail.value)
       case ValueExpr(v) => 
         renderValue(v.tail.value)
     ).mkString("\n")
@@ -51,11 +51,11 @@ given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
     override def version: "scala-3.3.0" =
       "scala-3.3.0"
 
-    private def renderType[T](tpe: Term.TypeLevel[T]): String =
+    private def renderType[T, X](tpe: Term.TypeLevel[T, X]): String =
       tpe match
         // application
-        case Term.TypeLevel.App1(qnt, tfun, targ) => s"${renderType(tfun)}[${renderType(targ)}]"
-        case Term.TypeLevel.App2(qnt, tfun, ta, tb) => s"${renderType(ta)} ${renderType(tfun)} ${renderType(tb)}"
+        case Term.TypeLevel.App1(qnt, tfun, targ) => s"${renderType(tfun.tail.value)}[${renderType(targ.tail.value)}]"
+        case Term.TypeLevel.App2(qnt, tfun, ta, tb) => s"${renderType(ta.tail.value)} ${renderType(tfun.tail.value)} ${renderType(tb.tail.value)}"
         // primitive
         case Term.TypeLevel.Var.BooleanType(_) => "Boolean"
         case Term.TypeLevel.Var.IntType(_) => "Int"
@@ -69,7 +69,7 @@ given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
       value match 
         // application
         case Term.ValueLevel.App1(q, f, a) => s"${renderValue(f.tail.value)}(${renderValue(a.tail.value)})"
-        case Term.ValueLevel.AppCtor1(q, t, a) => s"${renderType(t)}(${renderValue(a.tail.value)})"
+        case Term.ValueLevel.AppCtor1(q, t, a) => s"${renderType(t.tail.value)}(${renderValue(a.tail.value)})"
         case Term.ValueLevel.AppVargs(q, f, as*) => s"${renderValue(f.tail.value)}(${as.map(a => renderValue(a.tail.value)).mkString(", ")})"
         // function
         case Term.ValueLevel.Lam1(q, a, b) => s"${renderValue(a.tail.value)} => ${renderValue(b.tail.value)}"

--- a/modules/scala/src/main/scala/dc10/scala/version/package.scala
+++ b/modules/scala/src/main/scala/dc10/scala/version/package.scala
@@ -9,8 +9,8 @@ import dc10.scala.ast.Symbol.Term.ValueLevel.{App1, AppCtor1, AppVargs, Lam1}
 import dc10.scala.ast.Symbol.Term.ValueLevel.Var.{BooleanLiteral, IntLiteral, StringLiteral, ListCtor, UserDefinedValue}
 import dc10.scala.error.CompileError
 
-given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
-  new Renderer["scala-3.3.0", CompileError, List[Statement]]:
+given `3.3.1`: Renderer["scala-3.3.1", CompileError, List[Statement]] =
+  new Renderer["scala-3.3.1", CompileError, List[Statement]]:
 
     def render(input: List[Statement]): String = input.map(stmt => stmt match
       case d@CaseClassDef(_, _) =>
@@ -48,8 +48,8 @@ given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
     def renderErrors(errors: List[CompileError]): String =
       errors.map(_.toString()).mkString("\n")
 
-    override def version: "scala-3.3.0" =
-      "scala-3.3.0"
+    override def version: "scala-3.3.1" =
+      "scala-3.3.1"
 
     private def renderType[T, X](tpe: Term.TypeLevel[T, X]): String =
       tpe match

--- a/modules/scala/src/main/scala/dc10/scala/version/package.scala
+++ b/modules/scala/src/main/scala/dc10/scala/version/package.scala
@@ -23,21 +23,21 @@ given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
           case Empty(ms) => render(ms)
       case d@ValDef(_, _) =>
         d.value.tail.value match
-          case UserDefinedValue(nme, tpe, impl) =>  impl.fold(
+          case UserDefinedValue(_, nme, tpe, impl) =>  impl.fold(
               s"val ${nme}: ${renderType(tpe)}"
             )(
               i =>
                 s"val ${nme}: ${renderType(tpe)} = ${renderValue(i.tail.value)}"
             )
-          case Term.ValueLevel.App1(_, _) => ""
-          case Term.ValueLevel.AppCtor1(_, _) => ""
-          case Term.ValueLevel.AppVargs(_, _) => ""
-          case Term.ValueLevel.Lam1(_, _) => ""
-          case Term.ValueLevel.Var.BooleanLiteral(_) => ""
-          case Term.ValueLevel.Var.IntLiteral(_) => ""
-          case Term.ValueLevel.AppVargs(_, _*) => ""
-          case Term.ValueLevel.Var.StringLiteral(_) => ""
-          case Term.ValueLevel.Var.ListCtor() => ""
+          case Term.ValueLevel.App1(_, _, _) => ""
+          case Term.ValueLevel.AppCtor1(_, _, _) => ""
+          case Term.ValueLevel.AppVargs(_, _, _) => ""
+          case Term.ValueLevel.Lam1(_, _, _) => ""
+          case Term.ValueLevel.Var.BooleanLiteral(_, _) => ""
+          case Term.ValueLevel.Var.IntLiteral(_, _) => ""
+          case Term.ValueLevel.AppVargs(_, _, _*) => ""
+          case Term.ValueLevel.Var.StringLiteral(_, _) => ""
+          case Term.ValueLevel.Var.ListCtor(_) => ""
 
       case TypeExpr(t) => 
         renderType(t)
@@ -54,29 +54,29 @@ given `3.3.0`: Renderer["scala-3.3.0", CompileError, List[Statement]] =
     private def renderType[T](tpe: Term.TypeLevel[T]): String =
       tpe match
         // application
-        case Term.TypeLevel.App1(tfun, targ) => s"${renderType(tfun)}[${renderType(targ)}]"
-        case Term.TypeLevel.App2(tfun, ta, tb) => s"${renderType(ta)} ${renderType(tfun)} ${renderType(tb)}"
+        case Term.TypeLevel.App1(qnt, tfun, targ) => s"${renderType(tfun)}[${renderType(targ)}]"
+        case Term.TypeLevel.App2(qnt, tfun, ta, tb) => s"${renderType(ta)} ${renderType(tfun)} ${renderType(tb)}"
         // primitive
-        case Term.TypeLevel.Var.BooleanType => "Boolean"
-        case Term.TypeLevel.Var.IntType => "Int"
-        case Term.TypeLevel.Var.StringType => "String"
+        case Term.TypeLevel.Var.BooleanType(_) => "Boolean"
+        case Term.TypeLevel.Var.IntType(_) => "Int"
+        case Term.TypeLevel.Var.StringType(_) => "String"
         // complex
-        case Term.TypeLevel.Var.Function1Type => "=>"
-        case Term.TypeLevel.Var.ListType => "List"
-        case Term.TypeLevel.Var.UserDefinedType(s, i) => s
+        case Term.TypeLevel.Var.Function1Type(_) => "=>"
+        case Term.TypeLevel.Var.ListType(_) => "List"
+        case Term.TypeLevel.Var.UserDefinedType(q, s, i) => s
 
     private def renderValue[T, X](value: Term.ValueLevel[T, X]): String =
       value match 
         // application
-        case Term.ValueLevel.App1(f, a) => s"${renderValue(f.tail.value)}(${renderValue(a.tail.value)})"
-        case Term.ValueLevel.AppCtor1(t, a) => s"${renderType(t)}(${renderValue(a.tail.value)})"
-        case Term.ValueLevel.AppVargs(f, as*) => s"${renderValue(f.tail.value)}(${as.map(a => renderValue(a.tail.value)).mkString(", ")})"
+        case Term.ValueLevel.App1(q, f, a) => s"${renderValue(f.tail.value)}(${renderValue(a.tail.value)})"
+        case Term.ValueLevel.AppCtor1(q, t, a) => s"${renderType(t)}(${renderValue(a.tail.value)})"
+        case Term.ValueLevel.AppVargs(q, f, as*) => s"${renderValue(f.tail.value)}(${as.map(a => renderValue(a.tail.value)).mkString(", ")})"
         // function
-        case Term.ValueLevel.Lam1(a, b) => s"${renderValue(a.tail.value)} => ${renderValue(b.tail.value)}"
+        case Term.ValueLevel.Lam1(q, a, b) => s"${renderValue(a.tail.value)} => ${renderValue(b.tail.value)}"
         // primitive
-        case Term.ValueLevel.Var.BooleanLiteral(b) => s"$b"
-        case Term.ValueLevel.Var.IntLiteral(i) => s"$i"
-        case Term.ValueLevel.Var.StringLiteral(s) => s"\"${s}\""
+        case Term.ValueLevel.Var.BooleanLiteral(q, b) => s"$b"
+        case Term.ValueLevel.Var.IntLiteral(q, i) => s"$i"
+        case Term.ValueLevel.Var.StringLiteral(q, s) => s"\"${s}\""
         // complex
-        case Term.ValueLevel.Var.ListCtor() => s"List"
-        case Term.ValueLevel.Var.UserDefinedValue(s, t, i) => s
+        case Term.ValueLevel.Var.ListCtor(q) => s"List"
+        case Term.ValueLevel.Var.UserDefinedValue(q, s, t, i) => s

--- a/modules/scala/src/test/scala/dc10/scala/predef/FunctionsSuite.scala
+++ b/modules/scala/src/test/scala/dc10/scala/predef/FunctionsSuite.scala
@@ -4,7 +4,7 @@ import _root_.scala.language.implicitConversions
 import cats.implicits.*
 import dc10.scala.compiler.{compile, toString}
 import dc10.scala.dsl.{*, given}
-import dc10.scala.version.`3.3.0`
+import dc10.scala.version.`3.3.1`
 import munit.FunSuite
 
 class FunctionsSuite extends FunSuite:
@@ -17,7 +17,7 @@ class FunctionsSuite extends FunSuite:
       yield ()
     
     val obtained: String =
-      ast.compile.toString["scala-3.3.0"]
+      ast.compile.toString["scala-3.3.1"]
       
     val expected: String =
       """val f1: Int => String""".stripMargin
@@ -36,7 +36,7 @@ class FunctionsSuite extends FunSuite:
       yield ()
     
     val obtained: String =
-      ast.compile.toString["scala-3.3.0"]
+      ast.compile.toString["scala-3.3.1"]
       
     val expected: String =
       """|val f1: String => String = input => input

--- a/modules/scala/src/test/scala/dc10/scala/predef/datatype/ComplexTypesSuite.scala
+++ b/modules/scala/src/test/scala/dc10/scala/predef/datatype/ComplexTypesSuite.scala
@@ -6,7 +6,7 @@ import munit.FunSuite
 
 import dc10.scala.compiler.{compile, toString}
 import dc10.scala.dsl.{*, given}
-import dc10.scala.version.`3.3.0`
+import dc10.scala.version.`3.3.1`
 
 class ComplexTypesSuite extends FunSuite:
 
@@ -17,7 +17,7 @@ class ComplexTypesSuite extends FunSuite:
     def ast = CASECLASS[Person, String]("Person", VAL("name", STRING))
     
     val obtained: String =
-      ast.compile.toString["scala-3.3.0"]
+      ast.compile.toString["scala-3.3.1"]
       
     val expected: String =
       """case class Person(val name: String)""".stripMargin
@@ -35,7 +35,7 @@ class ComplexTypesSuite extends FunSuite:
       yield ()
     
     val obtained: String =
-      ast.compile.toString["scala-3.3.0"]
+      ast.compile.toString["scala-3.3.1"]
       
     val expected: String =
       """|val l1: List[Int]
@@ -56,7 +56,7 @@ class ComplexTypesSuite extends FunSuite:
       yield ()
     
     val obtained: String =
-      ast.compile.toString["scala-3.3.0"]
+      ast.compile.toString["scala-3.3.1"]
       
     val expected: String =
       """|val l1: List[Int] = List(1, 2, 3)

--- a/modules/scala/src/test/scala/dc10/scala/predef/datatype/PrimitiveTypesSuite.scala
+++ b/modules/scala/src/test/scala/dc10/scala/predef/datatype/PrimitiveTypesSuite.scala
@@ -11,7 +11,7 @@ class PrimitiveTypeSuite extends FunSuite:
 
   // compile
   import dc10.scala.compiler.{compile, toString}
-  import dc10.scala.version.`3.3.0`
+  import dc10.scala.version.`3.3.1`
 
   test("val dec"):
 
@@ -26,7 +26,7 @@ class PrimitiveTypeSuite extends FunSuite:
       yield ()
     
     val obtained: String =
-      ast.compile.toString["scala-3.3.0"]
+      ast.compile.toString["scala-3.3.1"]
       
     val expected: String =
       """|val t: Boolean
@@ -51,7 +51,7 @@ class PrimitiveTypeSuite extends FunSuite:
       yield ()
     
     val obtained: String =
-      ast.compile.toString["scala-3.3.0"]
+      ast.compile.toString["scala-3.3.1"]
       
     val expected: String =
       """|val t: Boolean = true

--- a/modules/scala/src/test/scala/dc10/scala/predef/file/FilesSuite.scala
+++ b/modules/scala/src/test/scala/dc10/scala/predef/file/FilesSuite.scala
@@ -13,7 +13,7 @@ class PrimitiveTypeSuite extends FunSuite:
 
   // compile
   import dc10.scala.compiler.{compile, toVirtualFile}
-  import dc10.scala.version.`3.3.0`
+  import dc10.scala.version.`3.3.1`
 
   test("val dec"):
 
@@ -28,7 +28,7 @@ class PrimitiveTypeSuite extends FunSuite:
       yield ()
     )
     val obtained: Either[List[CompileError], List[String]] =
-      ast.compile.toVirtualFile["scala-3.3.0"]
+      ast.compile.toVirtualFile["scala-3.3.1"]
         .map(fs => fs.map(vf => vf.contents))
       
     val expected: Either[List[CompileError], List[String]] =


### PR DESCRIPTION
Groundwork for quantitative types:
 - quantities: add quantities to terms (to be exposed in a `Variables` dsl for building statements while checking quantities)
 - dependencies: functorize terms so we can `fix` them, or rather `cofree` them so that we can associate arbitrary values to term trees (e.g., a length value to a vector type)